### PR TITLE
Fixed initialAngleInRadians typo in CannonBall.java

### DIFF
--- a/src/edu/macalester/comp127/hw2/CannonBall.java
+++ b/src/edu/macalester/comp127/hw2/CannonBall.java
@@ -32,7 +32,7 @@ public class CannonBall {
         //
         // To compute the initial velocity:
         //
-        //double initialAngleRadians = Math.toRadians(initialAngle);
+        //double initialAngleInRadians = Math.toRadians(initialAngle);
         //initialSpeed * cos(initialAngleInRadians)   // initial x velocity
         //initialSpeed * -sin(initialAngleInRadians)  // initial y velocity
         //


### PR DESCRIPTION
Variable for initial angle in radians is defined as initialAngleRadians but initialAngleInRadians is used. There is a typo in the variable name. 